### PR TITLE
Update public API in fs.dart to a bit more idiomatic.

### DIFF
--- a/example/lib/capture_status.dart
+++ b/example/lib/capture_status.dart
@@ -32,7 +32,7 @@ class _CaptureStatusState extends State<CaptureStatus> with FSStatusListener {
             status = "Started";
           }
         }));
-    FS.getCurrentSession().then((id) => setState(() {
+    FS.currentSession.then((id) => setState(() {
           this.id = id ?? "";
         }));
 
@@ -53,7 +53,7 @@ class _CaptureStatusState extends State<CaptureStatus> with FSStatusListener {
     setState(() {
       status = "Started";
       this.url = url;
-      FS.getCurrentSession().then((id) => setState(() {
+      FS.currentSession.then((id) => setState(() {
             this.id = id ?? "";
           }));
     });
@@ -80,7 +80,7 @@ class _CaptureStatusState extends State<CaptureStatus> with FSStatusListener {
             const TextButton(onPressed: FS.restart, child: Text("Restart")),
             TextButton(
                 onPressed: () {
-                  FS.getCurrentSessionURL(true).then((url) => setState(() {
+                  FS.getCurrentSessionURL(now: true).then((url) => setState(() {
                         urlNow = url ?? "";
                       }));
                 },

--- a/example/lib/fs_version.dart
+++ b/example/lib/fs_version.dart
@@ -24,7 +24,7 @@ class _FSVersionState extends State<FSVersion> {
     // Platform messages may fail, so we use a try/catch PlatformException.
     // We also handle the message potentially returning null.
     try {
-      fsVersion = await FS.fsVersion() ?? 'Unknown Fullstory version';
+      fsVersion = await FS.fsVersion ?? 'Unknown Fullstory version';
     } on PlatformException {
       fsVersion = 'Failed to get Fullstory version.';
     }

--- a/lib/fs.dart
+++ b/lib/fs.dart
@@ -10,7 +10,7 @@ export 'fs_status_listener.dart';
 /// Also note that methods may drop data if called when there is no Fullstory session active.
 class FS {
   /// Version of the underlying native Fullstory framework, e.g. '1.54.0'
-  static Future<String?> fsVersion() {
+  static Future<String?> get fsVersion {
     return FullstoryFlutterPlatform.instance.fsVersion();
   }
 
@@ -62,7 +62,7 @@ class FS {
   /// Identify a user and associate current and future sessions with that user.
   ///
   /// Will end the current session and begin a new one if a different uid was previously set.
-  /// Also allows custom userVars, see [FS.setUserVars()]
+  /// Also allows custom userVars, see [FS.setUserVars]
   ///
   /// For more information, see https://developer.fullstory.com/mobile/flutter/identification/identify-users/
   static Future<void> identify(String uid, [Map<String, Object?>? userVars]) {
@@ -73,7 +73,7 @@ class FS {
     return FullstoryFlutterPlatform.instance.identify(args);
   }
 
-  /// If a user ID was previously set via [FS.identify()], this will end the session, clear the user ID, and begin a new anonymous session.
+  /// If a user ID was previously set via [FS.identify], this will end the session, clear the user ID, and begin a new anonymous session.
   ///
   /// For more information, see https://developer.fullstory.com/mobile/flutter/identification/anonymize-users/
   static Future<void> anonymize() {
@@ -93,19 +93,19 @@ class FS {
 
   /// Returns the ID of the current Fullstory session.
   ///
-  /// See also: [FS.getCurrentSessionURL()]
+  /// See also: [FS.getCurrentSessionURL]
   ///
   /// For more information, see https://developer.fullstory.com/mobile/flutter/get-session-details/
-  static Future<String?> getCurrentSession() {
+  static Future<String?> get currentSession {
     return FullstoryFlutterPlatform.instance.getCurrentSession();
   }
 
   /// Returns the URL to view the current Fullstory session.
   ///
-  /// If the optional `now` parameter is set to `true`, the URL will begin the session from the current timestamp rather than the start of the session.
+  /// If the optional [now] parameter is set to `true`, the URL will begin the session from the current timestamp rather than the start of the session.
   ///
   /// For more information, see https://developer.fullstory.com/mobile/flutter/get-session-details/
-  static Future<String?> getCurrentSessionURL([bool now = false]) {
+  static Future<String?> getCurrentSessionURL({bool now = false}) {
     return FullstoryFlutterPlatform.instance.getCurrentSessionURL(now);
   }
 

--- a/test/fullstory_flutter_test.dart
+++ b/test/fullstory_flutter_test.dart
@@ -87,6 +87,6 @@ void main() {
     MockFullstoryFlutterPlatform fakePlatform = MockFullstoryFlutterPlatform();
     FullstoryFlutterPlatform.instance = fakePlatform;
 
-    expect(await FS.fsVersion(), '42');
+    expect(await FS.fsVersion, '42');
   });
 }


### PR DESCRIPTION
* Switch unargumented gets to getters: https://dart.dev/effective-dart/design#do-use-getters-for-operations-that-conceptually-access-properties
* Switch `now` param in `getCurrentSessionUrl()` to named: https://dart.dev/effective-dart/design#avoid-positional-boolean-parameters
* Also fix some linking in the dartdoc.

The last change Effective Dart would recommend is to [remove the top-level FS class](https://dart.dev/effective-dart/design#avoid-defining-a-class-that-contains-only-static-members) and do namespacing on the import, but I don't think that's actually a great idea here. This is consistent with the other mobile APIs and doesn't really hinder readability.

Also, I ultimately decided the named params for logging were the most idiomatic approach for what we wanted, so leaving as is.