### PR TITLE
Adjust log levels to match session replay console.

### DIFF
--- a/android/src/main/kotlin/com/fullstory/fullstory_flutter/FullstoryFlutterPlugin.kt
+++ b/android/src/main/kotlin/com/fullstory/fullstory_flutter/FullstoryFlutterPlugin.kt
@@ -48,7 +48,7 @@ class FullstoryFlutterPlugin() : FlutterPlugin, MethodCallHandler {
           1 -> FS.LogLevel.INFO
           2 -> FS.LogLevel.WARN
           3 -> FS.LogLevel.ERROR
-          else -> FS.LogLevel.INFO // default. Alternatively we could error here.
+          else -> result.error("INVALID_ARGUMENTS", "Invaliid level for log, expected level in 1-3, got ${levelB}")
         }
         FS.log(level, message)
         result.success(null)

--- a/android/src/main/kotlin/com/fullstory/fullstory_flutter/FullstoryFlutterPlugin.kt
+++ b/android/src/main/kotlin/com/fullstory/fullstory_flutter/FullstoryFlutterPlugin.kt
@@ -45,11 +45,9 @@ class FullstoryFlutterPlugin() : FlutterPlugin, MethodCallHandler {
         val message = call.argument<String>("message")
         val level = when (levelB) {
           0 -> FS.LogLevel.LOG // A.K.A. Verbose
-          1 -> FS.LogLevel.DEBUG
-          2 -> FS.LogLevel.INFO
-          3 -> FS.LogLevel.WARN
-          4 -> FS.LogLevel.ERROR
-          5 -> FS.LogLevel.ERROR // Assert on iOS; not actually enabled at the moment because it's a reserved keyword in dart.
+          1 -> FS.LogLevel.INFO
+          2 -> FS.LogLevel.WARN
+          3 -> FS.LogLevel.ERROR
           else -> FS.LogLevel.INFO // default. Alternatively we could error here.
         }
         FS.log(level, message)

--- a/android/src/main/kotlin/com/fullstory/fullstory_flutter/FullstoryFlutterPlugin.kt
+++ b/android/src/main/kotlin/com/fullstory/fullstory_flutter/FullstoryFlutterPlugin.kt
@@ -48,7 +48,7 @@ class FullstoryFlutterPlugin() : FlutterPlugin, MethodCallHandler {
           1 -> FS.LogLevel.INFO
           2 -> FS.LogLevel.WARN
           3 -> FS.LogLevel.ERROR
-          else -> result.error("INVALID_ARGUMENTS", "Invaliid level for log, expected level in 1-3, got ${levelB}")
+          else -> result.error("INVALID_ARGUMENTS", "Unexpected log level, expected value 0-3, got ${levelB}")
         }
         FS.log(level, message)
         result.success(null)

--- a/ios/Classes/FullstoryFlutterPlugin.swift
+++ b/ios/Classes/FullstoryFlutterPlugin.swift
@@ -39,19 +39,17 @@ public class FullstoryFlutterPlugin: NSObject, FlutterPlugin, FSDelegate {
             }
             var levelValue: FSEventLogLevel;
             switch level {
-            case 0, 1:
+            case 0:
                 levelValue = FSLOG_DEBUG
-            case 2:
+            case 1:
                 levelValue = FSLOG_INFO
-            case 3:
+            case 2:
                 levelValue = FSLOG_WARNING
-            case 4:
+            case 3:
                 levelValue = FSLOG_ERROR
-            case 5:
-                levelValue = FSLOG_ASSERT
             default:
                 result(FlutterError(code: "INVALID_ARGUMENTS",
-                                    message: "Unexpected log level, expected value 0-5, got \(level)",
+                                    message: "Unexpected log level, expected value 0-3, got \(level)",
                                     details: nil))
                 return
             }

--- a/lib/fs_log_level.dart
+++ b/lib/fs_log_level.dart
@@ -1,12 +1,12 @@
 /// Log levels. Controls how logs appear in the Dev tools > Console section of a Fullstory session replay
-/// 
+///
 /// These correspond to the levels shown in session replay,
 /// not the the levels used in Android/iOS logging.
 enum FSLogLevel {
   // Note: the order matters; the index is used to match to the appropriate value in the android and ios platform code
 
   /// Lower than default level logging.
-  /// 
+  ///
   /// Equivalent to debug level on Android and iOS.
   log,
 
@@ -16,8 +16,8 @@ enum FSLogLevel {
   /// Warn log level
   warn,
 
-  /// Error log level. 
-  /// 
+  /// Error log level.
+  ///
   /// Will appear in in both the console and the event list in Fullstory
   error,
 

--- a/lib/fs_log_level.dart
+++ b/lib/fs_log_level.dart
@@ -1,12 +1,14 @@
 /// Log levels. Controls how logs appear in the Dev tools > Console section of a Fullstory session replay
+/// 
+/// These correspond to the levels shown in session replay,
+/// not the the levels used in Android/iOS logging.
 enum FSLogLevel {
   // Note: the order matters; the index is used to match to the appropriate value in the android and ios platform code
 
-  /// Verbose on Android, clamps to Debug on iOS
+  /// Lower than default level logging.
+  /// 
+  /// Equivalent to debug level on Android and iOS.
   log,
-
-  /// Debug log level, currently combined with `log` in Fullstory's console.
-  debug,
 
   /// Info log level, default
   info,
@@ -14,8 +16,10 @@ enum FSLogLevel {
   /// Warn log level
   warn,
 
-  /// Error log level. Will appear in in both the console and the event list in Fullstory
+  /// Error log level. 
+  /// 
+  /// Will appear in in both the console and the event list in Fullstory
   error,
 
-  //assert, // treated as error on iOS, not available on Android. Disabled here because it's a reserved keyword in dart.
+  // exception, Not currently supported by underlying platforms.
 }


### PR DESCRIPTION
It seems like neither platform uses the "Exception" level shown in the console.

Also, let me know if you'd rather squash some of the PRs for this together. I'm defaulting to small, focused PRs, but I'm happy to combine them if preferred.