### PR TITLE
Return early if an bad log level is detected.

### DIFF
--- a/android/src/main/kotlin/com/fullstory/fullstory_flutter/FullstoryFlutterPlugin.kt
+++ b/android/src/main/kotlin/com/fullstory/fullstory_flutter/FullstoryFlutterPlugin.kt
@@ -49,7 +49,14 @@ class FullstoryFlutterPlugin() : FlutterPlugin, MethodCallHandler {
           1 -> FS.LogLevel.INFO
           2 -> FS.LogLevel.WARN
           3 -> FS.LogLevel.ERROR
-          else -> result.error("INVALID_ARGUMENTS", "Unexpected log level, expected value 0-3, got ${levelB}")
+          else -> {
+            result.error(
+              "INVALID_ARGUMENTS",
+              "Unexpected log level, expected value 0-3, got ${levelB}",
+              null
+            )
+            return
+          }
         }
         FS.log(level, message)
         result.success(null)

--- a/android/src/test/kotlin/com/example/fullstory_flutter/FullstoryFlutterPluginTest.kt
+++ b/android/src/test/kotlin/com/example/fullstory_flutter/FullstoryFlutterPluginTest.kt
@@ -1,9 +1,10 @@
 package com.example.fullstory_flutter
 
+import com.fullstory.fullstory_flutter.FullstoryFlutterPlugin
 import io.flutter.plugin.common.MethodCall
 import io.flutter.plugin.common.MethodChannel
-import kotlin.test.Test
 import org.mockito.Mockito
+import kotlin.test.Test
 
 /*
  * This demonstrates a simple unit test of the Kotlin portion of this plugin's implementation.
@@ -12,16 +13,16 @@ import org.mockito.Mockito
  * line by running `./gradlew testDebugUnitTest` in the `example/android/` directory, or
  * you can run them directly from IDEs that support JUnit such as Android Studio.
  */
-
 internal class FullstoryFlutterPluginTest {
   @Test
-  fun onMethodCall_getPlatformVersion_returnsExpectedValue() {
+  fun onMethodCall_logWithBadLevel_returnsError() {
     val plugin = FullstoryFlutterPlugin()
 
-    val call = MethodCall("getPlatformVersion", null)
+    val call = MethodCall("log", mapOf("level" to 10, "message" to "test"))
     val mockResult: MethodChannel.Result = Mockito.mock(MethodChannel.Result::class.java)
     plugin.onMethodCall(call, mockResult)
 
-    Mockito.verify(mockResult).success("Android " + android.os.Build.VERSION.RELEASE)
+    Mockito.verify(mockResult).error(
+      "INVALID_ARGUMENTS", "Unexpected log level, expected value 0-3, got 10", null)
   }
 }


### PR DESCRIPTION
Also deletes the existing test, which was stale.

I discovered this by accident fiddling with the Android-side plugin tests. I don't think these are running in CI, so that will probably be the next thing to tackle.

Might then add some more tests, since it seems like these would offer us some quick value.