### PR TITLE
v0.2.0 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+## 0.2.0
+
+⚠️ BREAKING ⚠️
+
+- Changed `FS.currentSession()` (method) to `FS.currentSession` (property)
+- Changed `FS.fsVersion()` (method) to `FS.fsVersion` (property)
+- Changed `FS.getCurrentSessionURL([bool now = false])` (positional parameter) to `FS.getCurrentSessionURL({bool now = false})` (named parameter)
+- Removed `FSLogLevel.debug` to align log levels with Fullstory playback
+
+New:
+
+- Added `FS.page()` API and associated `FSPage` object and APIs
+
 ## 0.1.3
 
 - Update with links to developer docs.

--- a/README.md
+++ b/README.md
@@ -26,9 +26,9 @@ Most non-visual Fullstory APIs are supported:
 - `FS.shutdown()`
 - `FS.restart()`
 - `FS.setStatusListener(FSStatusListener? listener)`
-- `FS.getCurrentSession()` → `Future<String?>`
-- `FS.getCurrentSessionURL([bool now = false])` → `Future<String?>`
-- `FS.fsVersion()` → `Future<String?>`
+- `FS.getCurrentSession` → `Future<String?>`
+- `FS.getCurrentSessionURL({bool now = false})` → `Future<String?>`
+- `FS.fsVersion` → `Future<String?>`
 - `FS.resetIdleTimer()`
 
 Visual session replay is not currently supported, but is planned for a future release.


### PR DESCRIPTION
Also updated the readme with the changed APIs.

Since this is the afternoon before a long weekend, I think we should probably wait until tuesday to publish the release.

We'll also want to update https://developer.fullstory.com/mobile/flutter/ and possibly https://help.fullstory.com/hc/en-us/articles/27461129353239-Getting-Started-with-Fullstory-for-Flutter-Mobile-Apps - I'll get started on the former today.