### PR TITLE
Add PowerMock so we can mock static methods of FS

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -90,14 +90,17 @@ android {
 
 
     dependencies {
-        testImplementation("org.jetbrains.kotlin:kotlin-test")
-        testImplementation("org.mockito:mockito-core:5.0.0")
+        testImplementation "org.powermock:powermock-module-junit4:2.0.2"
+        testImplementation "org.powermock:powermock-api-mockito2:2.0.9"
+        testImplementation "junit:junit:4.13.2"
+
         implementation "com.fullstory:instrumentation-full:$fsDetectedVersion@aar" //e.g. 1.53.0@aar'
     }
 
     testOptions {
         unitTests.all {
-            useJUnitPlatform()
+            useJUnit()
+            jvmArgs '--add-opens', 'java.base/java.lang=ALL-UNNAMED'
 
             testLogging {
                events "passed", "skipped", "failed", "standardOut", "standardError"

--- a/android/src/test/kotlin/com/example/fullstory_flutter/FullstoryFlutterPluginTest.kt
+++ b/android/src/test/kotlin/com/example/fullstory_flutter/FullstoryFlutterPluginTest.kt
@@ -1,10 +1,18 @@
 package com.example.fullstory_flutter
 
+import com.fullstory.FS
 import com.fullstory.fullstory_flutter.FullstoryFlutterPlugin
 import io.flutter.plugin.common.MethodCall
 import io.flutter.plugin.common.MethodChannel
-import org.mockito.Mockito
-import kotlin.test.Test
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.verify
+import org.powermock.api.mockito.PowerMockito.mockStatic
+import org.powermock.api.mockito.PowerMockito.verifyStatic
+import org.powermock.core.classloader.annotations.PrepareForTest
+import org.powermock.modules.junit4.PowerMockRunner
 
 /*
  * This demonstrates a simple unit test of the Kotlin portion of this plugin's implementation.
@@ -13,16 +21,36 @@ import kotlin.test.Test
  * line by running `./gradlew testDebugUnitTest` in the `example/android/` directory, or
  * you can run them directly from IDEs that support JUnit such as Android Studio.
  */
+@RunWith(PowerMockRunner::class)
+@PrepareForTest(FS::class)
 internal class FullstoryFlutterPluginTest {
+  private lateinit var result: MethodChannel.Result
+  private lateinit var plugin: FullstoryFlutterPlugin
+
+  @Before
+  fun setUp() {
+    mockStatic(FS::class.java)
+    result = mock(MethodChannel.Result::class.java)
+    plugin = FullstoryFlutterPlugin()
+  }
+
   @Test
   fun onMethodCall_logWithBadLevel_returnsError() {
-    val plugin = FullstoryFlutterPlugin()
+    val call = MethodCall("log", mapOf("level" to 4, "message" to "test"))
+    plugin.onMethodCall(call, result)
 
-    val call = MethodCall("log", mapOf("level" to 10, "message" to "test"))
-    val mockResult: MethodChannel.Result = Mockito.mock(MethodChannel.Result::class.java)
+    verify(result).error(
+      "INVALID_ARGUMENTS", "Unexpected log level, expected value 0-3, got 4", null)
+  }
+
+  @Test
+  fun onMethodCall_log_logsAndReturnsSuccess() {
+    val call = MethodCall("log", mapOf("level" to 1, "message" to "test message"))
+    val mockResult: MethodChannel.Result = mock(MethodChannel.Result::class.java)
     plugin.onMethodCall(call, mockResult)
 
-    Mockito.verify(mockResult).error(
-      "INVALID_ARGUMENTS", "Unexpected log level, expected value 0-3, got 10", null)
+    verify(mockResult).success(null)
+    verifyStatic(FS::class.java)
+    FS.log(FS.LogLevel.INFO, "test message")
   }
 }


### PR DESCRIPTION
This will let us validate Android plugin behavior in unit tests.

I added 1 test as an example, I figure we can add more as needed for anything that gets added and isn't trivial.