### PR TITLE
Pages: rename pageVars to properties in FS.page(), and add optional propertyUpdates to page.start()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## 0.3.0
+
+⚠️ BREAKING ⚠️
+
+- Changed `FS.page(String pageName, {Map<String, Object?>? pageVars})` to `FS.page(String pageName, {Map<String, Object?>? properties})` (pageVars -> properties)
+
+New:
+
+- Added optional `propertyUpdates` parameter to `FSPage#start()`
+
 ## 0.2.0
 
 ⚠️ BREAKING ⚠️

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Fullstory's Flutter package exposes access to the Fullstory Native Mobile SDK fr
 Most non-visual Fullstory APIs are supported:
 
 - `FS.event(String name, [Map<String, Object?> properties = const {}])`
-- `FS.page(String pageName, [Map<String, Object?>? pageVars])` → `FSPage`
+- `FS.page(String pageName, {Map<String, Object?>? properties})` → `FSPage`
 - `FS.log({FSLogLevel level = FSLogLevel.info, required String message})`
 - `FS.identify(String uid, [Map<String, Object?>? userVars])`
 - `FS.setUserVars(Map<String, Object?> userVars)`

--- a/android/src/main/kotlin/com/fullstory/fullstory_flutter/FullstoryFlutterPlugin.kt
+++ b/android/src/main/kotlin/com/fullstory/fullstory_flutter/FullstoryFlutterPlugin.kt
@@ -122,10 +122,10 @@ class FullstoryFlutterPlugin() : FlutterPlugin, MethodCallHandler {
       // Pages API
       "page" -> {
         val pageName = call.argument<String>("pageName")
-        val pageVars = call.argument<Map<String, Any>>("pageVars")
+        val properties = call.argument<Map<String, Any>>("properties")
 
         if (pageName != null) {
-          val page = FS.page(pageName, pageVars)
+          val page = FS.page(pageName, properties)
           val pageId = nextPageID++
           pages[pageId] = page
           result.success(pageId)

--- a/android/src/main/kotlin/com/fullstory/fullstory_flutter/FullstoryFlutterPlugin.kt
+++ b/android/src/main/kotlin/com/fullstory/fullstory_flutter/FullstoryFlutterPlugin.kt
@@ -134,10 +134,11 @@ class FullstoryFlutterPlugin() : FlutterPlugin, MethodCallHandler {
         }
       }
       "startPage" -> {
-        val pageId: Int? = call.arguments as? Int;
+        val pageId = call.argument<Int>("pageId")
+        val propertyUpdates = call.argument<Map<String, Any>>("propertyUpdates")
         val page = pages[pageId]
         if (page != null) {
-          page.start()
+          page.start(propertyUpdates)
           result.success(null)
         } else {
           result.error("INVALID_PAGE", "No active page found with the given ID", null)

--- a/example/example.md
+++ b/example/example.md
@@ -513,16 +513,20 @@ class _PagesState extends State<Pages> {
       // Dispose of the current page before creating a new one
       _currentPage?.dispose();
       _currentPage = FS.page('DemoPage$_pageCounter',
-          pageVars: {'initialKey': 'initialValue'});
+          properties: {'initialKey': 'initialValue'});
       _pageCounter++;
     });
   }
 
-  void _startPageSession() {
+  void _startPage() {
     _currentPage?.start();
   }
 
-  void _endPageSession() {
+  void _startPageWithProperties() {
+    _currentPage?.start(propertyUpdates: {'initialKey': 'newValue'});
+  }
+
+  void _endPage() {
     _currentPage?.end();
   }
 
@@ -555,11 +559,15 @@ class _PagesState extends State<Pages> {
               child: const Text('Create New Page'),
             ),
             ElevatedButton(
-              onPressed: _startPageSession,
+              onPressed: _startPage,
               child: Text("Start Page $_pageCounter"),
             ),
             ElevatedButton(
-              onPressed: _endPageSession,
+              onPressed: _startPageWithProperties,
+              child: Text("Start Page $_pageCounter with properties"),
+            ),
+            ElevatedButton(
+              onPressed: _endPage,
               child: Text("End Page $_pageCounter"),
             ),
             ElevatedButton(

--- a/example/lib/pages.dart
+++ b/example/lib/pages.dart
@@ -29,7 +29,7 @@ class _PagesState extends State<Pages> {
       // Dispose of the current page before creating a new one
       _currentPage?.dispose();
       _currentPage = FS.page('DemoPage$_pageCounter',
-          pageVars: {'initialKey': 'initialValue'});
+          properties: {'initialKey': 'initialValue'});
       _pageCounter++;
     });
   }

--- a/example/lib/pages.dart
+++ b/example/lib/pages.dart
@@ -38,6 +38,10 @@ class _PagesState extends State<Pages> {
     _currentPage?.start();
   }
 
+  void _startPageWithProperties() {
+    _currentPage?.start(propertyUpdates: {'initialKey': 'newValue'});
+  }
+
   void _endPage() {
     _currentPage?.end();
   }
@@ -73,6 +77,10 @@ class _PagesState extends State<Pages> {
             ElevatedButton(
               onPressed: _startPage,
               child: Text("Start Page $_pageCounter"),
+            ),
+            ElevatedButton(
+              onPressed: _startPageWithProperties,
+              child: Text("Start Page $_pageCounter with properties"),
             ),
             ElevatedButton(
               onPressed: _endPage,

--- a/example/lib/pages.dart
+++ b/example/lib/pages.dart
@@ -34,11 +34,11 @@ class _PagesState extends State<Pages> {
     });
   }
 
-  void _startPageSession() {
+  void _startPage() {
     _currentPage?.start();
   }
 
-  void _endPageSession() {
+  void _endPage() {
     _currentPage?.end();
   }
 
@@ -71,11 +71,11 @@ class _PagesState extends State<Pages> {
               child: const Text('Create New Page'),
             ),
             ElevatedButton(
-              onPressed: _startPageSession,
+              onPressed: _startPage,
               child: Text("Start Page $_pageCounter"),
             ),
             ElevatedButton(
-              onPressed: _endPageSession,
+              onPressed: _endPage,
               child: Text("End Page $_pageCounter"),
             ),
             ElevatedButton(

--- a/ios/Classes/FullstoryFlutterPlugin.swift
+++ b/ios/Classes/FullstoryFlutterPlugin.swift
@@ -127,12 +127,17 @@ public class FullstoryFlutterPlugin: NSObject, FlutterPlugin, FSDelegate {
                 result(FlutterError(code: "INVALID_ARGUMENT", message: "Page name and properties are required", details: nil))
             }
         case "startPage":
-            if let pageId = call.arguments as? Int,
-               let page = self.pages[pageId] {
-                page.start()
-                result(nil)
+            if let args = call.arguments as? [String: Any],
+               let pageId = args["pageId"] as? Int,
+               let propertyUpdates = args["propertyUpdates"] as? [String: Any] {
+                if let page = self.pages[pageId] {
+                    page.start(withPropertyUpdates: propertyUpdates)
+                    result(nil)
+                } else {
+                    result(FlutterError(code: "INVALID_PAGE", message: "No active page found with the given ID", details: nil))
+                }
             } else {
-                result(FlutterError(code: "INVALID_PAGE", message: "No active page found with the given ID", details: nil))
+                result(FlutterError(code: "INVALID_ARGUMENT", message: "Page ID and propertyUpdates are required", details: nil))
             }
         case "endPage":
             if let pageId = call.arguments as? Int,

--- a/ios/Classes/FullstoryFlutterPlugin.swift
+++ b/ios/Classes/FullstoryFlutterPlugin.swift
@@ -117,14 +117,14 @@ public class FullstoryFlutterPlugin: NSObject, FlutterPlugin, FSDelegate {
         case "page":
             if let args = call.arguments as? [String: Any],
                let pageName = args["pageName"] as? String,
-               let pageVars = args["pageVars"] as? [String: Any] {
-                let page = FS.page(withName: pageName, properties: pageVars)
+               let properties = args["properties"] as? [String: Any] {
+                let page = FS.page(withName: pageName, properties: properties)
                 let pageId = self.nextPageID
                 self.nextPageID += 1
                 self.pages[pageId] = page
                 result(pageId)
             } else {
-                result(FlutterError(code: "INVALID_ARGUMENT", message: "Page name and pageVars are required", details: nil))
+                result(FlutterError(code: "INVALID_ARGUMENT", message: "Page name and properties are required", details: nil))
             }
         case "startPage":
             if let pageId = call.arguments as? Int,

--- a/lib/fs.dart
+++ b/lib/fs.dart
@@ -131,9 +131,9 @@ class FS {
   /// Call [FSPage.start()] on the returned [FSPage] object to mark the page as active.
   ///
   /// For more information, see https://help.fullstory.com/hc/en-us/articles/14795945510295-Mobile-App-Pages-in-Fullstory
-  static FSPage page(String pageName, {Map<String, Object?>? pageVars}) {
+  static FSPage page(String pageName, {Map<String, Object?>? properties}) {
     return FSPage._(
-        FullstoryFlutterPlatform.instance.page(pageName, pageVars ?? {}));
+        FullstoryFlutterPlatform.instance.page(pageName, properties ?? {}));
   }
 }
 

--- a/lib/fs.dart
+++ b/lib/fs.dart
@@ -158,8 +158,9 @@ class FSPage {
   }
 
   /// Start the current page. May be called multiple times if the page is visited more than once.
-  Future<void> start() async {
-    return FullstoryFlutterPlatform.instance.startPage(await _id);
+  Future<void> start({Map<String, Object?>? propertyUpdates}) async {
+    return FullstoryFlutterPlatform.instance
+        .startPage(await _id, propertyUpdates ?? {});
   }
 
   /// End the current page. Optional. Starting a different page implicitly ends the current one.

--- a/lib/src/fullstory_flutter_method_channel.dart
+++ b/lib/src/fullstory_flutter_method_channel.dart
@@ -124,8 +124,11 @@ class MethodChannelFullstoryFlutter extends FullstoryFlutterPlatform {
   }
 
   @override
-  Future<void> startPage(int pageId) {
-    return methodChannel.invokeMethod('startPage', pageId);
+  Future<void> startPage(int pageId, Map<String, Object?> propertyUpdates) {
+    return methodChannel.invokeMethod('startPage', {
+      'pageId': pageId,
+      'propertyUpdates': propertyUpdates,
+    });
   }
 
   @override

--- a/lib/src/fullstory_flutter_method_channel.dart
+++ b/lib/src/fullstory_flutter_method_channel.dart
@@ -115,10 +115,10 @@ class MethodChannelFullstoryFlutter extends FullstoryFlutterPlatform {
   // page() here asynchronously returns the ID of the native page object
   // FS.page() will use the ID future to synchronously create a new FSPage object
   @override
-  Future<int> page(String pageName, Map<String, Object?> pageVars) async {
+  Future<int> page(String pageName, Map<String, Object?> properties) async {
     final id = await methodChannel.invokeMethod<int>('page', {
       'pageName': pageName,
-      'pageVars': pageVars,
+      'properties': properties,
     });
     return id!;
   }

--- a/lib/src/fullstory_flutter_platform_interface.dart
+++ b/lib/src/fullstory_flutter_platform_interface.dart
@@ -83,7 +83,7 @@ abstract class FullstoryFlutterPlatform extends PlatformInterface {
   }
   // todo: webview injection disable
 
-  Future<int> page(String pageName, Map<String, dynamic> pageVars) {
+  Future<int> page(String pageName, Map<String, Object?> properties) {
     throw UnimplementedError();
   }
 
@@ -96,7 +96,7 @@ abstract class FullstoryFlutterPlatform extends PlatformInterface {
   }
 
   Future<void> updatePageProperties(
-      int pageId, Map<String, dynamic> properties) {
+      int pageId, Map<String, Object?> properties) {
     throw UnimplementedError();
   }
 

--- a/lib/src/fullstory_flutter_platform_interface.dart
+++ b/lib/src/fullstory_flutter_platform_interface.dart
@@ -87,7 +87,7 @@ abstract class FullstoryFlutterPlatform extends PlatformInterface {
     throw UnimplementedError();
   }
 
-  Future<void> startPage(int pageId) {
+  Future<void> startPage(int pageId, Map<String, Object?> propertyUpdates) {
     throw UnimplementedError();
   }
 

--- a/test/fullstory_flutter_test.dart
+++ b/test/fullstory_flutter_test.dart
@@ -80,7 +80,7 @@ class MockFullstoryFlutterPlatform
   }
 
   @override
-  Future<int> page(String pageName, Map<String, dynamic> pageVars) {
+  Future<int> page(String pageName, Map<String, Object?> properties) {
     throw UnimplementedError();
   }
 
@@ -96,7 +96,7 @@ class MockFullstoryFlutterPlatform
 
   @override
   Future<void> updatePageProperties(
-      int pageId, Map<String, dynamic> properties) {
+      int pageId, Map<String, Object?> properties) {
     throw UnimplementedError();
   }
 }

--- a/test/fullstory_flutter_test.dart
+++ b/test/fullstory_flutter_test.dart
@@ -90,7 +90,7 @@ class MockFullstoryFlutterPlatform
   }
 
   @override
-  Future<void> startPage(int pageId) {
+  Future<void> startPage(int pageId, Map<String, Object?>? propertyUpdates) {
     throw UnimplementedError();
   }
 


### PR DESCRIPTION
This really should have been part of #5 but I missed both of these until I was working on the developer docs.

(`pageVars` is the old name, from before mobile even supported pages.)

I'm still thinking about how to make a better demo for the example app. Maybe a product list screen and then opening each product is a new page with properties for product id, name, and maybe a dynamic property like size. But that's for another day.