### PR TITLE
Rename getCurrentSessionUrl to currentSessionUrl

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,8 @@ Most non-visual Fullstory APIs are supported:
 - `FS.shutdown()`
 - `FS.restart()`
 - `FS.setStatusListener(FSStatusListener? listener)`
-- `FS.getCurrentSession` → `Future<String?>`
-- `FS.getCurrentSessionURL({bool now = false})` → `Future<String?>`
+- `FS.currentSession` → `Future<String?>`
+- `FS.currentSessionURL({bool now = false})` → `Future<String?>`
 - `FS.fsVersion` → `Future<String?>`
 - `FS.resetIdleTimer()`
 

--- a/example/example.md
+++ b/example/example.md
@@ -41,7 +41,7 @@ class _CaptureStatusState extends State<CaptureStatus> with FSStatusListener {
     super.initState();
 
     // grab the current session URL & ID in case it has already started
-    FS.getCurrentSessionURL().then((url) => setState(() {
+    FS.currentSessionURL().then((url) => setState(() {
           if (url != null) {
             // if there is a url, we know the session started
             this.url = url;
@@ -96,7 +96,7 @@ class _CaptureStatusState extends State<CaptureStatus> with FSStatusListener {
             const TextButton(onPressed: FS.restart, child: Text("Restart")),
             TextButton(
                 onPressed: () {
-                  FS.getCurrentSessionURL(now: true).then((url) => setState(() {
+                  FS.currentSessionURL(now: true).then((url) => setState(() {
                         urlNow = url ?? "";
                       }));
                 },

--- a/example/lib/capture_status.dart
+++ b/example/lib/capture_status.dart
@@ -25,7 +25,7 @@ class _CaptureStatusState extends State<CaptureStatus> with FSStatusListener {
     super.initState();
 
     // grab the current session URL & ID in case it has already started
-    FS.getCurrentSessionURL().then((url) => setState(() {
+    FS.currentSessionURL().then((url) => setState(() {
           if (url != null) {
             // if there is a url, we know the session started
             this.url = url;
@@ -80,7 +80,7 @@ class _CaptureStatusState extends State<CaptureStatus> with FSStatusListener {
             const TextButton(onPressed: FS.restart, child: Text("Restart")),
             TextButton(
                 onPressed: () {
-                  FS.getCurrentSessionURL(now: true).then((url) => setState(() {
+                  FS.currentSessionURL(now: true).then((url) => setState(() {
                         urlNow = url ?? "";
                       }));
                 },

--- a/lib/fs.dart
+++ b/lib/fs.dart
@@ -1,7 +1,8 @@
-import 'src/fullstory_flutter_platform_interface.dart';
 import 'fs_log_level.dart';
-export 'fs_log_level.dart';
 import 'fs_status_listener.dart';
+import 'src/fullstory_flutter_platform_interface.dart';
+
+export 'fs_log_level.dart';
 export 'fs_status_listener.dart';
 
 /// Fullstory API
@@ -99,7 +100,7 @@ class FS {
 
   /// Returns the ID of the current Fullstory session.
   ///
-  /// See also: [FS.getCurrentSessionURL]
+  /// See also: [FS.currentSessionURL]
   ///
   /// For more information, see https://developer.fullstory.com/mobile/flutter/get-session-details/
   static Future<String?> get currentSession {
@@ -111,7 +112,7 @@ class FS {
   /// If the optional [now] parameter is set to `true`, the URL will begin the session from the current timestamp rather than the start of the session.
   ///
   /// For more information, see https://developer.fullstory.com/mobile/flutter/get-session-details/
-  static Future<String?> getCurrentSessionURL({bool now = false}) {
+  static Future<String?> currentSessionURL({bool now = false}) {
     return FullstoryFlutterPlatform.instance.getCurrentSessionURL(now);
   }
 


### PR DESCRIPTION
Also: Looks like dartfmt found a small import/export order tweak it wanted when I saved.