### PR TITLE
Fix src's analysis options include to point to a real file

### DIFF
--- a/lib/src/analysis_options.yaml
+++ b/lib/src/analysis_options.yaml
@@ -1,4 +1,4 @@
-include: ../analysis_options.yaml
+include: ../../analysis_options.yaml
 
 linter:
   rules:

--- a/lib/src/analysis_options.yaml
+++ b/lib/src/analysis_options.yaml
@@ -1,5 +1,3 @@
-include: ../../analysis_options.yaml
-
 linter:
   rules:
     - public_member_api_docs: false # these are not public, but the rule doesn't seem to realize this


### PR DESCRIPTION
We have an additional rule for the src directory, but it's include was invalid (needed another ../).

This used to be fine, but apparently Flutter 3.29 now notices and fails in this case.