### PR TITLE
Updates FS version detection to support add-to-app use-case

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -14,13 +14,11 @@ buildscript {
     }
 }
 
-allprojects {
-    repositories {
-        google()
-        mavenCentral()
-        mavenLocal()
-        maven { url "https://maven.fullstory.com" }
-    }
+repositories {
+    google()
+    mavenCentral()
+    mavenLocal()
+    maven { url "https://maven.fullstory.com" }
 }
 
 apply plugin: "com.android.library"
@@ -51,50 +49,32 @@ android {
         minSdk = 21
     }
 
-    // determine FS version app is using
-    // based on https://github.com/fullstorydev/fullstory-react-native/blob/4af1ab9c040cb647fb0f0afe25df42b986fd11de/android/build.gradle#L55-L96
-    def rootScriptClassPathFiles = rootProject.buildscript.getScriptClassPath().getAsFiles()
-    String searchString = 'gradle-plugin-local-'
-    String fsDetectedVersion = null
-    for (File file : rootScriptClassPathFiles) {
-        int lastIndex = file.name.lastIndexOf(searchString)
-        if (lastIndex < 0) {
-            continue
-        }
-
-        if (!file.name.endsWith('.jar')) {
-            continue
-        }
-
-        int endIndex = file.name.length() - 4
-        int startIndex = lastIndex + searchString.length()
-        fsDetectedVersion = file.name.substring(startIndex, endIndex)
-        break
-    }
-
-    if (fsDetectedVersion == null) {
-        throw new GradleException('Unable to determine FullStory version, please verify your root build file is properly configured')
-    }
-
-    def versionRegex = /(?<major>\d+)\.(?<minor>\d+)\.(?<patch>\d+)/
-    def match = fsDetectedVersion =~ versionRegex
-    if (match.matches()) {
-        def major = match.group('major') as Integer
-        def minor = match.group('minor') as Integer
-        if (major < 1 || (major == 1 && minor < 54)) {
-            throw new GradleException("FullStory SDK version 1.54.0 or later is required, but version $fsDetectedVersion was detected. Please update to a newer version of FullStory.")
+    // Determine the version of FS to compile against
+    String fsVersion
+    if (isModuleProject(project)) {
+        if (project.hasProperty('fsTarget')) {
+            String fsTargetStr = project.getProperty('fsTarget')
+            FSVersion targetVersion = parseVersion(fsTargetStr)
+            if (targetVersion == null) {
+                throw new GradleException("Failed to parse `fsTarget` version: $fsTargetStr")
+            }
+            validateVersion(targetVersion)
+            fsVersion = targetVersion
+        } else {
+            fsVersion = FSConstants.MIN_FS_VERSION
         }
     } else {
-        throw new GradleException('Unable to determine FullStory version, please verify your root build file is properly configured')
+        FSVersion version = getFSVersionFromBuildScript(project)
+        validateVersion(version)
+        fsVersion = version.toString()
     }
-
 
     dependencies {
         testImplementation "org.powermock:powermock-module-junit4:2.0.2"
         testImplementation "org.powermock:powermock-api-mockito2:2.0.9"
         testImplementation "junit:junit:4.13.2"
 
-        implementation "com.fullstory:instrumentation-full:$fsDetectedVersion@aar" //e.g. 1.53.0@aar'
+        compileOnly "com.fullstory:instrumentation-full:$fsVersion@aar"
     }
 
     testOptions {
@@ -109,4 +89,92 @@ android {
             }
         }
     }
+}
+
+private static boolean isModuleProject(Project project) {
+    Project flutterProject = project.rootProject.findProject(":flutter")
+    if (flutterProject != null) {
+        def modulePlugins = flutterProject.plugins
+        return modulePlugins.hasPlugin(FSConstants.FLUTTER_GRADLE_PLUGIN_ID)\
+            && modulePlugins.hasPlugin(FSConstants.ANDROID_LIBRARY_PLUGIN_ID)
+    }
+    return false
+}
+
+private static FSVersion getFSVersionFromBuildScript(Project project) {
+    def rootScriptClassPathFiles = project.rootProject.buildscript.getScriptClassPath().getAsFiles()
+    String searchString = 'gradle-plugin-local-'
+    for (File file : rootScriptClassPathFiles) {
+        int lastIndex = file.name.lastIndexOf(searchString)
+        if (lastIndex < 0) {
+            continue
+        }
+
+        if (!file.name.endsWith('.jar')) {
+            continue
+        }
+
+        int endIndex = file.name.length() - 4
+        int startIndex = lastIndex + searchString.length()
+        return parseVersion(file.name.substring(startIndex, endIndex))
+    }
+    return null
+}
+
+private static FSVersion parseVersion(String versionStr) {
+    def versionRegex = /(?<major>\d+)\.(?<minor>\d+)\.(?<patch>\d+)/
+    def match = versionStr =~ versionRegex
+    if (match.matches()) {
+        def major = match.group('major') as Integer
+        def minor = match.group('minor') as Integer
+        def patch = match.group('patch') as Integer
+        return new FSVersion(major, minor, patch)
+    } else {
+        return null
+    }
+}
+
+private static void validateVersion(FSVersion version) {
+    if (version == null) {
+        throw new GradleException('Unable to determine Fullstory version, please verify your project is properly '
+            + 'configured to use the Fullstory plugin: '
+            + 'https://help.fullstory.com/hc/en-us/articles/360040596093-Getting-Started-with-Android-Data-Capture')
+    }
+    if (version.isLessThan(FSConstants.MIN_FS_VERSION)) {
+        throw new GradleException("Fullstory SDK version ${FSConstants.MIN_FS_VERSION} or later is required, but "
+            + "version $version was detected. Please update to a newer version of Fullstory.")
+    }
+}
+
+class FSVersion {
+    public final int major
+    public final int minor
+    public final int patch
+
+    FSVersion(int major, int minor, int patch) {
+        this.major = major
+        this.minor = minor
+        this.patch = patch
+    }
+
+    boolean isLessThan(FSVersion other) {
+        if (major != other.major) {
+            return major < other.major
+        }
+        if (minor != other.minor) {
+            return minor < other.minor
+        }
+        return patch < other.patch
+    }
+
+    @Override
+    String toString() {
+        return "$major.$minor.$patch"
+    }
+}
+
+class FSConstants {
+    static final FLUTTER_GRADLE_PLUGIN_ID = "dev.flutter.flutter-gradle-plugin"
+    static final ANDROID_LIBRARY_PLUGIN_ID = "com.android.library"
+    static final MIN_FS_VERSION = new FSVersion(1, 54, 0)
 }

--- a/android/src/main/kotlin/com/fullstory/fullstory_flutter/FullstoryFlutterPlugin.kt
+++ b/android/src/main/kotlin/com/fullstory/fullstory_flutter/FullstoryFlutterPlugin.kt
@@ -30,7 +30,7 @@ class FullstoryFlutterPlugin() : FlutterPlugin, MethodCallHandler {
   }
 
   override fun onMethodCall(call: MethodCall, result: Result) {
-    //println("\n\nFullStory method call received: ${call.method}, ${call.arguments}\n\n")
+    //println("\n\nFullstory method call received: ${call.method}, ${call.arguments}\n\n")
     when (call.method) {
       "fsVersion" -> result.success(FS.fsVersion())
       "shutdown" -> {

--- a/example/android/.gitignore
+++ b/example/android/.gitignore
@@ -5,6 +5,7 @@ gradle-wrapper.jar
 /gradlew.bat
 /local.properties
 GeneratedPluginRegistrant.java
+.cxx
 
 # Remember to never publicly share your keystore.
 # See https://flutter.dev/to/reference-keystore

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -2,6 +2,8 @@ allprojects {
     repositories {
         google()
         mavenCentral()
+        mavenLocal()
+        maven { url "https://maven.fullstory.com" }
     }
 }
 
@@ -15,17 +17,4 @@ subprojects {
 
 tasks.register("clean", Delete) {
     delete rootProject.buildDir
-}
-
-buildscript {
-  repositories {
-    google()
-    mavenCentral()
-    gradlePluginPortal()
-    mavenLocal()
-    maven { url "https://maven.fullstory.com" }
-  }
-  dependencies {
-    classpath 'com.fullstory:gradle-plugin-local:1.54.0'
-  }
 }

--- a/example/android/settings.gradle
+++ b/example/android/settings.gradle
@@ -13,6 +13,8 @@ pluginManagement {
         google()
         mavenCentral()
         gradlePluginPortal()
+        mavenLocal()
+        maven { url "https://maven.fullstory.com" }
     }
 }
 
@@ -20,6 +22,7 @@ plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
     id "com.android.application" version '8.7.1' apply false
     id "org.jetbrains.kotlin.android" version "1.8.22" apply false
+    id "com.fullstory" version "1.57.0" apply false
 }
 
 include ":app"

--- a/example/example.md
+++ b/example/example.md
@@ -548,7 +548,7 @@ class _PagesState extends State<Pages> {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-        title: const Text('FullStory Pages API'),
+        title: const Text('Fullstory Pages API'),
       ),
       body: Center(
         child: Column(

--- a/example/lib/pages.dart
+++ b/example/lib/pages.dart
@@ -64,7 +64,7 @@ class _PagesState extends State<Pages> {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-        title: const Text('FullStory Pages API'),
+        title: const Text('Fullstory Pages API'),
       ),
       body: Center(
         child: Column(

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -5,42 +5,42 @@ packages:
     dependency: transitive
     description:
       name: async
-      sha256: "947bfcf187f74dbc5e146c9eb9c0f10c9f8b30743e341481c1e2ed3ecc18c20c"
+      sha256: d2872f9c19731c2e5f10444b14686eb7cc85c76274bd6c16e1816bff9a3bab63
       url: "https://pub.dev"
     source: hosted
-    version: "2.11.0"
+    version: "2.12.0"
   boolean_selector:
     dependency: transitive
     description:
       name: boolean_selector
-      sha256: "6cfb5af12253eaf2b368f07bacc5a80d1301a071c73360d746b7f2e32d762c66"
+      sha256: "8aab1771e1243a5063b8b0ff68042d67334e3feab9e95b9490f9a6ebf73b42ea"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.1"
+    version: "2.1.2"
   characters:
     dependency: transitive
     description:
       name: characters
-      sha256: "04a925763edad70e8443c99234dc3328f442e811f1d8fd1a72f1c8ad0f69a605"
+      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.0"
+    version: "1.4.0"
   clock:
     dependency: transitive
     description:
       name: clock
-      sha256: cb6d7f03e1de671e34607e909a7213e31d7752be4fb66a86d29fe1eb14bfb5cf
+      sha256: fddb70d9b5277016c77a80201021d40a2247104d9f4aa7bab7157b7e3f05b84b
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.1"
+    version: "1.1.2"
   collection:
     dependency: transitive
     description:
       name: collection
-      sha256: ee67cb0715911d28db6bf4af1026078bd6f0128b07a5f66fb2ed94ec6783c09a
+      sha256: "2f5709ae4d3d59dd8f7cd309b4e023046b57d8a6c82130785d2b0e5868084e76"
       url: "https://pub.dev"
     source: hosted
-    version: "1.18.0"
+    version: "1.19.1"
   cupertino_icons:
     dependency: "direct main"
     description:
@@ -53,18 +53,18 @@ packages:
     dependency: transitive
     description:
       name: fake_async
-      sha256: "511392330127add0b769b75a987850d136345d9227c6b94c96a04cf4a391bf78"
+      sha256: "6a95e56b2449df2273fd8c45a662d6947ce1ebb7aafe80e550a3f68297f3cacc"
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.1"
+    version: "1.3.2"
   file:
     dependency: transitive
     description:
       name: file
-      sha256: "5fc22d7c25582e38ad9a8515372cd9a93834027aacf1801cf01164dac0ffa08c"
+      sha256: a3b4f84adafef897088c160faf7dfffb7696046cb13ae90b508c2cbc95d3b8d4
       url: "https://pub.dev"
     source: hosted
-    version: "7.0.0"
+    version: "7.0.1"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -99,7 +99,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.1.3"
+    version: "0.3.0"
   integration_test:
     dependency: "direct dev"
     description: flutter
@@ -109,18 +109,18 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "3f87a60e8c63aecc975dda1ceedbc8f24de75f09e4856ea27daf8958f2f0ce05"
+      sha256: c35baad643ba394b40aac41080300150a4f08fd0fd6a10378f8f7c6bc161acec
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.5"
+    version: "10.0.8"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: "932549fb305594d82d7183ecd9fa93463e9914e1b67cacc34bc40906594a1806"
+      sha256: f8b613e7e6a13ec79cfdc0e97638fddb3ab848452eff057653abd3edba760573
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.5"
+    version: "3.0.9"
   leak_tracker_testing:
     dependency: transitive
     description:
@@ -141,10 +141,10 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: d2323aa2060500f906aa31a895b4030b6da3ebdcc5619d14ce1aada65cd161cb
+      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.16+1"
+    version: "0.12.17"
   material_color_utilities:
     dependency: transitive
     description:
@@ -157,26 +157,26 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: bdb68674043280c3428e9ec998512fb681678676b3c54e773629ffe74419f8c7
+      sha256: e3641ec5d63ebf0d9b41bd43201a66e3fc79a65db5f61fc181f04cd27aab950c
       url: "https://pub.dev"
     source: hosted
-    version: "1.15.0"
+    version: "1.16.0"
   path:
     dependency: transitive
     description:
       name: path
-      sha256: "087ce49c3f0dc39180befefc60fdb4acd8f8620e5682fe2476afd0b3688bb4af"
+      sha256: "75cca69d1490965be98c73ceaea117e8a04dd21217b37b292c9ddbec0d955bc5"
       url: "https://pub.dev"
     source: hosted
-    version: "1.9.0"
+    version: "1.9.1"
   platform:
     dependency: transitive
     description:
       name: platform
-      sha256: "9b71283fc13df574056616011fb138fd3b793ea47cc509c189a6c3fa5f8a1a65"
+      sha256: "5d6b1b0036a5f331ebc77c850ebc8506cbc1e9416c27e59b439f917a902a4984"
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.5"
+    version: "3.1.6"
   plugin_platform_interface:
     dependency: transitive
     description:
@@ -189,47 +189,47 @@ packages:
     dependency: transitive
     description:
       name: process
-      sha256: "21e54fd2faf1b5bdd5102afd25012184a6793927648ea81eea80552ac9405b32"
+      sha256: "107d8be718f120bbba9dcd1e95e3bd325b1b4a4f07db64154635ba03f2567a0d"
       url: "https://pub.dev"
     source: hosted
-    version: "5.0.2"
+    version: "5.0.3"
   sky_engine:
     dependency: transitive
     description: flutter
     source: sdk
-    version: "0.0.99"
+    version: "0.0.0"
   source_span:
     dependency: transitive
     description:
       name: source_span
-      sha256: "53e943d4206a5e30df338fd4c6e7a077e02254531b138a15aec3bd143c1a8b3c"
+      sha256: "254ee5351d6cb365c859e20ee823c3bb479bf4a293c22d17a9f1bf144ce86f7c"
       url: "https://pub.dev"
     source: hosted
-    version: "1.10.0"
+    version: "1.10.1"
   stack_trace:
     dependency: transitive
     description:
       name: stack_trace
-      sha256: "73713990125a6d93122541237550ee3352a2d84baad52d375a4cad2eb9b7ce0b"
+      sha256: "8b27215b45d22309b5cddda1aa2b19bdfec9df0e765f2de506401c071d38d1b1"
       url: "https://pub.dev"
     source: hosted
-    version: "1.11.1"
+    version: "1.12.1"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
-      sha256: ba2aa5d8cc609d96bbb2899c28934f9e1af5cddbd60a827822ea467161eb54e7
+      sha256: "969e04c80b8bcdf826f8f16579c7b14d780458bd97f56d107d3950fdbeef059d"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.2"
+    version: "2.1.4"
   string_scanner:
     dependency: transitive
     description:
       name: string_scanner
-      sha256: "556692adab6cfa87322a115640c11f13cb77b3f076ddcc5d6ae3c20242bedcde"
+      sha256: "921cd31725b72fe181906c6a94d987c78e3b98c2e205b397ea399d4054872b43"
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.0"
+    version: "1.4.1"
   sync_http:
     dependency: transitive
     description:
@@ -242,18 +242,18 @@ packages:
     dependency: transitive
     description:
       name: term_glyph
-      sha256: a29248a84fbb7c79282b40b8c72a1209db169a2e0542bce341da992fe1bc7e84
+      sha256: "7f554798625ea768a7518313e58f83891c7f5024f88e46e7182a4558850a4b8e"
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.1"
+    version: "1.2.2"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: "5b8a98dafc4d5c4c9c72d8b31ab2b23fc13422348d2997120294d3bac86b4ddb"
+      sha256: fb31f383e2ee25fbbfe06b40fe21e1e458d14080e3c67e7ba0acfde4df4e0bbd
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.2"
+    version: "0.7.4"
   vector_math:
     dependency: transitive
     description:
@@ -266,18 +266,18 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: "5c5f338a667b4c644744b661f309fb8080bb94b18a7e91ef1dbd343bed00ed6d"
+      sha256: "0968250880a6c5fe7edc067ed0a13d4bae1577fe2771dcf3010d52c4a9d3ca14"
       url: "https://pub.dev"
     source: hosted
-    version: "14.2.5"
+    version: "14.3.1"
   webdriver:
     dependency: transitive
     description:
       name: webdriver
-      sha256: "003d7da9519e1e5f329422b36c4dcdf18d7d2978d1ba099ea4e45ba490ed845e"
+      sha256: "3d773670966f02a646319410766d3b5e1037efb7f07cc68f844d5e06cd4d61c8"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.3"
+    version: "3.0.4"
   webview_flutter:
     dependency: "direct main"
     description:
@@ -311,5 +311,5 @@ packages:
     source: hosted
     version: "3.16.0"
 sdks:
-  dart: ">=3.5.3 <4.0.0"
+  dart: ">=3.7.0-0 <4.0.0"
   flutter: ">=3.24.0"

--- a/example_module/README.md
+++ b/example_module/README.md
@@ -1,5 +1,5 @@
 # Fullstory using Flutter Modules
 
-This example demonstrates how to use Fullstory with a Flutter module. 
+This example demonstrates how to use Fullstory with a Flutter module.
 
 For examples of Fullstory API use, see the example app in `../example`.

--- a/example_module/android_using_prebuilt_module/README.md
+++ b/example_module/android_using_prebuilt_module/README.md
@@ -2,7 +2,7 @@
 
 An example Android application used in the Flutter add-to-app samples. For more
 information on how to use it, see the [README](../README.md) file located in the
-[/add_to_app](/add_to_app) directory of this repo.
+[/example_module](/example_module) directory of this repo.
 
 ## Getting Started
 

--- a/example_module/flutter_module/.gitignore
+++ b/example_module/flutter_module/.gitignore
@@ -39,3 +39,5 @@ build/
 .android/
 .ios/
 .flutter-plugins
+
+.flutter-plugins-dependencies

--- a/example_module/flutter_module/pubspec.lock
+++ b/example_module/flutter_module/pubspec.lock
@@ -5,10 +5,10 @@ packages:
     dependency: transitive
     description:
       name: async
-      sha256: "758e6d74e971c3e5aceb4110bfd6698efc7f501675bcfe0c775459a8140750eb"
+      sha256: d2872f9c19731c2e5f10444b14686eb7cc85c76274bd6c16e1816bff9a3bab63
       url: "https://pub.dev"
     source: hosted
-    version: "2.13.0"
+    version: "2.12.0"
   boolean_selector:
     dependency: transitive
     description:
@@ -53,10 +53,10 @@ packages:
     dependency: transitive
     description:
       name: fake_async
-      sha256: "5368f224a74523e8d2e7399ea1638b37aecfca824a3cc4dfdf77bf1fa905ac44"
+      sha256: "6a95e56b2449df2273fd8c45a662d6947ce1ebb7aafe80e550a3f68297f3cacc"
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.3"
+    version: "1.3.2"
   file:
     dependency: transitive
     description:
@@ -96,10 +96,10 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "6bb818ecbdffe216e81182c2f0714a2e62b593f4a4f13098713ff1685dfb6ab0"
+      sha256: c35baad643ba394b40aac41080300150a4f08fd0fd6a10378f8f7c6bc161acec
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.9"
+    version: "10.0.8"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
@@ -261,18 +261,18 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: ddfa8d30d89985b96407efce8acbdd124701f96741f2d981ca860662f1c0dc02
+      sha256: "0968250880a6c5fe7edc067ed0a13d4bae1577fe2771dcf3010d52c4a9d3ca14"
       url: "https://pub.dev"
     source: hosted
-    version: "15.0.0"
+    version: "14.3.1"
   webdriver:
     dependency: transitive
     description:
       name: webdriver
-      sha256: "2f3a14ca026957870cfd9c635b83507e0e51d8091568e90129fbf805aba7cade"
+      sha256: "3d773670966f02a646319410766d3b5e1037efb7f07cc68f844d5e06cd4d61c8"
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.0"
+    version: "3.0.4"
 sdks:
   dart: ">=3.7.0-0 <4.0.0"
   flutter: ">=3.27.0"

--- a/example_module/ios_using_prebuilt_module/README.md
+++ b/example_module/ios_using_prebuilt_module/README.md
@@ -2,7 +2,7 @@
 
 An example iOS application used in the Flutter add-to-app samples. For more
 information on how to use it, see the [README](../README.md) file located in the
-[/add_to_app](/add_to_app) directory of this repo.
+[/example_module](/example_module) directory of this repo.
 
 ## Getting Started
 

--- a/ios/Classes/FullstoryFlutterPlugin.swift
+++ b/ios/Classes/FullstoryFlutterPlugin.swift
@@ -20,7 +20,7 @@ public class FullstoryFlutterPlugin: NSObject, FlutterPlugin, FSDelegate {
     }
 
     public func handle(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
-        // print("FullStory method call received:", call.method, call.arguments ?? "")
+        // print("Fullstory method call received:", call.method, call.arguments ?? "")
         switch call.method {
         case "fsVersion":
             result(FS.fsVersion())


### PR DESCRIPTION
fullstory-flutter currently fails on Android for module projects (add-to-app use-case). This is because it detects which version of FS is in the build, but it isn't present for this configuration. Support is added with the following:
 - Detects add-to-app builds
 - Allows target FS version to be supplied for add-to-app builds via command line with -PfsTarget=<version>

The dependency on the fullstory instrumentation-full aar is also updated to compileOnly from implementation. It is only needed for referencing the API; the actual classes are included by the app. We may want to change this back to implementation in the future once the FS gradle plugin can validate the resolved artifact version matches the plugin version.