### PR TITLE
Demonstrate how to get webview replay working with Flutter.

### DIFF
--- a/example/example.md
+++ b/example/example.md
@@ -608,9 +608,7 @@ class _WebViewState extends State<WebView> {
       // so that Fullstory can inject its JS. Otherwise, you will only see
       // a message about disabled JS in replay.
       ..setJavaScriptMode(JavaScriptMode.unrestricted)
-      ..loadRequest(
-        Uri.parse('https://www.fullstory.com/'),
-      );
+      ..loadHtmlString(html);
   }
 
   @override
@@ -618,5 +616,33 @@ class _WebViewState extends State<WebView> {
     return WebViewWidget(controller: controller);
   }
 }
+
+const html = '''
+<html>
+  <head>
+    <title>WebView Example</title>
+    <style>
+      body {
+        font-family: sans-serif;
+        text-align: center;
+        padding: 20px;
+      }
+
+      h1 {
+        font-size: 5rem;
+      }
+
+      p {
+        font-size: 2rem;
+      }
+    </style>
+  </head>
+  <body>
+    <h1>WebView Example</h1>
+    <p>This is a simple webview example.</p>
+    <p>Fullstory should work here.</p>
+  </body>
+</html>
+''';
 ```
 

--- a/example/example.md
+++ b/example/example.md
@@ -588,7 +588,7 @@ import 'package:flutter/material.dart';
 import 'package:webview_flutter/webview_flutter.dart';
 
 // Basic webview example.
-// No Fullstory APIs are used here, and the webview's contents are not currently visible in playback.
+// Native Fullstory handles webviews, as long as Flutter allows JS there.
 
 class WebView extends StatefulWidget {
   const WebView({super.key});
@@ -604,6 +604,10 @@ class _WebViewState extends State<WebView> {
   void initState() {
     super.initState();
     controller = WebViewController()
+      // To allow Fullstory in your Flutter webview, ensure JS is unrestricted
+      // so that Fullstory can inject its JS. Otherwise, you will only see
+      // a message about disabled JS in replay.
+      ..setJavaScriptMode(JavaScriptMode.unrestricted)
       ..loadRequest(
         Uri.parse('https://www.fullstory.com/'),
       );

--- a/example/lib/webview.dart
+++ b/example/lib/webview.dart
@@ -2,7 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:webview_flutter/webview_flutter.dart';
 
 // Basic webview example.
-// No Fullstory APIs are used here, and the webview's contents are not currently visible in playback.
+// Native Fullstory handles webviews, as long as Flutter allows JS there.
 
 class WebView extends StatefulWidget {
   const WebView({super.key});
@@ -18,6 +18,10 @@ class _WebViewState extends State<WebView> {
   void initState() {
     super.initState();
     controller = WebViewController()
+      // To allow Fullstory in your Flutter webview, ensure JS is unrestricted
+      // so that Fullstory can inject its JS. Otherwise, you will only see
+      // a message about disabled JS in replay.
+      ..setJavaScriptMode(JavaScriptMode.unrestricted)
       ..loadRequest(
         Uri.parse('https://www.fullstory.com/'),
       );

--- a/example/lib/webview.dart
+++ b/example/lib/webview.dart
@@ -22,9 +22,7 @@ class _WebViewState extends State<WebView> {
       // so that Fullstory can inject its JS. Otherwise, you will only see
       // a message about disabled JS in replay.
       ..setJavaScriptMode(JavaScriptMode.unrestricted)
-      ..loadRequest(
-        Uri.parse('https://www.fullstory.com/'),
-      );
+      ..loadHtmlString(html);
   }
 
   @override
@@ -32,3 +30,31 @@ class _WebViewState extends State<WebView> {
     return WebViewWidget(controller: controller);
   }
 }
+
+const html = '''
+<html>
+  <head>
+    <title>WebView Example</title>
+    <style>
+      body {
+        font-family: sans-serif;
+        text-align: center;
+        padding: 20px;
+      }
+
+      h1 {
+        font-size: 5rem;
+      }
+
+      p {
+        font-size: 2rem;
+      }
+    </style>
+  </head>
+  <body>
+    <h1>WebView Example</h1>
+    <p>This is a simple webview example.</p>
+    <p>Fullstory should work here.</p>
+  </body>
+</html>
+''';


### PR DESCRIPTION
Notes:
* This currently only works for Android, there's separate work to make iOS recognize the Flutter Webview.
* fullstory.com currently doesn't get correctly captured, changing the URL to google.com get's captured and replayed though.