### PR TITLE
Add navigator observer wrapping page APIs

### DIFF
--- a/example/example.md
+++ b/example/example.md
@@ -9,6 +9,7 @@ From https://github.com/fullstorydev/fullstory-flutter/tree/main/example/lib
 * [identity.dart](#identitydart)
 * [log.dart](#logdart)
 * [main.dart](#maindart)
+* [nav_demo.dart](#nav_demodart)
 * [pages.dart](#pagesdart)
 * [webview.dart](#webviewdart)
 
@@ -380,6 +381,8 @@ class _LogState extends State<Log> {
 ```dart
 import 'package:flutter/material.dart';
 import 'package:fullstory_flutter/fs.dart';
+import 'package:fullstory_flutter/navigator_observer.dart';
+import 'package:fullstory_flutter_example/nav_demo.dart';
 
 import 'capture_status.dart';
 import 'identity.dart';
@@ -413,10 +416,14 @@ class _MyAppState extends State<MyApp> {
     Pages(),
     FSVersion(),
     WebView(),
+    OpenNavDemo(),
   ];
 
   // Create a list of FSPage objects to represent the different screens in the app
-  // We'll call .start() on each one when it's associated screen is displayed
+  // We'll call .start() on each one when it's associated screen is displayed.
+  //
+  // Manual calls like this can be intermixed with the
+  // [FSNavigatorObserver].
   static final List<FSPage> _pages =
       _screens.map((s) => FS.page(s.toString())).toList();
 
@@ -434,6 +441,20 @@ class _MyAppState extends State<MyApp> {
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
+      routes: {
+        '/navDemo': (_) => const NavDemo(),
+      },
+      navigatorObservers: [
+        FSNavigatorObserver(
+          initialProperties: (current, previous) => {
+            if (current.settings.name == '/navDemo') 'navDemoFirstVisit': true,
+          },
+          updateProperties: (current, previous) => {
+            if (current.settings.name == '/navDemo') 'navDemoFirstVisit': false,
+            'navDemoLaterVisit': true,
+          },
+        )
+      ],
       home: Scaffold(
         appBar: AppBar(
           title: const Text('Fullstory Flutter test app'),
@@ -474,6 +495,48 @@ class _MyAppState extends State<MyApp> {
             ),
           );
         }),
+      ),
+    );
+  }
+}
+```
+
+## nav_demo.dart
+```dart
+import 'package:flutter/material.dart';
+
+/// A second page in the app to demo use of [FullstoryNavigatorObserver].
+class NavDemo extends StatelessWidget {
+  const NavDemo({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Navigator Observer Demo'),
+      ),
+      body: Container(
+        margin: const EdgeInsets.symmetric(horizontal: 24),
+        child: const Text('Welcome to the Navigator Observer Demo!\n'
+            'Hit back to return to the main screen.'),
+      ),
+    );
+  }
+}
+
+/// A small widget with a button to open [NavDemo]
+class OpenNavDemo extends StatelessWidget {
+  const OpenNavDemo({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      margin: const EdgeInsets.symmetric(horizontal: 24),
+      child: ElevatedButton(
+        onPressed: () {
+          Navigator.pushNamed(context, '/navDemo');
+        },
+        child: const Text('Open Navigator Observer Demo'),
       ),
     );
   }

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -41,8 +41,8 @@ class _MyAppState extends State<MyApp> {
   // Create a list of FSPage objects to represent the different screens in the app
   // We'll call .start() on each one when it's associated screen is displayed.
   //
-  // Manual calls like this can be intermixed with the 
-  // [FullstoryNavigatorObserver].
+  // Manual calls like this can be intermixed with the
+  // [FSNavigatorObserver].
   static final List<FSPage> _pages =
       _screens.map((s) => FS.page(s.toString())).toList();
 
@@ -63,17 +63,17 @@ class _MyAppState extends State<MyApp> {
       routes: {
         '/navDemo': (_) => const NavDemo(),
       },
-      navigatorObservers: [FSNavigatorObserver(
-        initialProperties: (current, previous) => {
-          if(current.settings.name == '/navDemo')
-            'navDemoFirstVisit': true,
-        },
-        updateProperties: (current, previous) => {
-          if(current.settings.name == '/navDemo')
-            'navDemoFirstVisit': false,
+      navigatorObservers: [
+        FSNavigatorObserver(
+          initialProperties: (current, previous) => {
+            if (current.settings.name == '/navDemo') 'navDemoFirstVisit': true,
+          },
+          updateProperties: (current, previous) => {
+            if (current.settings.name == '/navDemo') 'navDemoFirstVisit': false,
             'navDemoLaterVisit': true,
-        },
-      )],
+          },
+        )
+      ],
       home: Scaffold(
         appBar: AppBar(
           title: const Text('Fullstory Flutter test app'),

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:fullstory_flutter/fs.dart';
+import 'package:fullstory_flutter/navigator_observer.dart';
+import 'package:fullstory_flutter_example/nav_demo.dart';
 
 import 'capture_status.dart';
 import 'identity.dart';
@@ -33,10 +35,14 @@ class _MyAppState extends State<MyApp> {
     Pages(),
     FSVersion(),
     WebView(),
+    OpenNavDemo(),
   ];
 
   // Create a list of FSPage objects to represent the different screens in the app
-  // We'll call .start() on each one when it's associated screen is displayed
+  // We'll call .start() on each one when it's associated screen is displayed.
+  //
+  // Manual calls like this can be intermixed with the 
+  // [FullstoryNavigatorObserver].
   static final List<FSPage> _pages =
       _screens.map((s) => FS.page(s.toString())).toList();
 
@@ -54,6 +60,20 @@ class _MyAppState extends State<MyApp> {
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
+      routes: {
+        '/navDemo': (_) => const NavDemo(),
+      },
+      navigatorObservers: [FSNavigatorObserver(
+        initialProperties: (current, previous) => {
+          if(current.settings.name == '/navDemo')
+            'navDemoFirstVisit': true,
+        },
+        updateProperties: (current, previous) => {
+          if(current.settings.name == '/navDemo')
+            'navDemoFirstVisit': false,
+            'navDemoLaterVisit': true,
+        },
+      )],
       home: Scaffold(
         appBar: AppBar(
           title: const Text('Fullstory Flutter test app'),

--- a/example/lib/nav_demo.dart
+++ b/example/lib/nav_demo.dart
@@ -1,0 +1,38 @@
+import 'package:flutter/material.dart';
+
+/// A second page in the app to demo use of [FullstoryNavigatorObserver].
+class NavDemo extends StatelessWidget {
+  const NavDemo({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Navigator Observer Demo'),
+      ),
+      body: Container(
+        margin: const EdgeInsets.symmetric(horizontal: 24),
+        child: const Text('Welcome to the Navigator Observer Demo!\n'
+            'Hit back to return to the main screen.'),
+      ),
+    );
+  }
+}
+
+/// A small widget with a button to open [NavDemo]
+class OpenNavDemo extends StatelessWidget {
+  const OpenNavDemo({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      margin: const EdgeInsets.symmetric(horizontal: 24),
+      child: ElevatedButton(
+        onPressed: () {
+          Navigator.pushNamed(context, '/navDemo');
+        },
+        child: const Text('Open Navigator Observer Demo'),
+      ),
+    );
+  }
+}

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -5,10 +5,10 @@ packages:
     dependency: transitive
     description:
       name: async
-      sha256: d2872f9c19731c2e5f10444b14686eb7cc85c76274bd6c16e1816bff9a3bab63
+      sha256: "758e6d74e971c3e5aceb4110bfd6698efc7f501675bcfe0c775459a8140750eb"
       url: "https://pub.dev"
     source: hosted
-    version: "2.12.0"
+    version: "2.13.0"
   boolean_selector:
     dependency: transitive
     description:
@@ -53,10 +53,10 @@ packages:
     dependency: transitive
     description:
       name: fake_async
-      sha256: "6a95e56b2449df2273fd8c45a662d6947ce1ebb7aafe80e550a3f68297f3cacc"
+      sha256: "5368f224a74523e8d2e7399ea1638b37aecfca824a3cc4dfdf77bf1fa905ac44"
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.2"
+    version: "1.3.3"
   file:
     dependency: transitive
     description:
@@ -99,7 +99,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.3.0"
+    version: "0.4.0"
   integration_test:
     dependency: "direct dev"
     description: flutter
@@ -109,10 +109,10 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: c35baad643ba394b40aac41080300150a4f08fd0fd6a10378f8f7c6bc161acec
+      sha256: "6bb818ecbdffe216e81182c2f0714a2e62b593f4a4f13098713ff1685dfb6ab0"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.8"
+    version: "10.0.9"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
@@ -266,18 +266,18 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: "0968250880a6c5fe7edc067ed0a13d4bae1577fe2771dcf3010d52c4a9d3ca14"
+      sha256: ddfa8d30d89985b96407efce8acbdd124701f96741f2d981ca860662f1c0dc02
       url: "https://pub.dev"
     source: hosted
-    version: "14.3.1"
+    version: "15.0.0"
   webdriver:
     dependency: transitive
     description:
       name: webdriver
-      sha256: "3d773670966f02a646319410766d3b5e1037efb7f07cc68f844d5e06cd4d61c8"
+      sha256: "2f3a14ca026957870cfd9c635b83507e0e51d8091568e90129fbf805aba7cade"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.4"
+    version: "3.1.0"
   webview_flutter:
     dependency: "direct main"
     description:

--- a/example_module/flutter_module/pubspec.lock
+++ b/example_module/flutter_module/pubspec.lock
@@ -5,10 +5,10 @@ packages:
     dependency: transitive
     description:
       name: async
-      sha256: d2872f9c19731c2e5f10444b14686eb7cc85c76274bd6c16e1816bff9a3bab63
+      sha256: "758e6d74e971c3e5aceb4110bfd6698efc7f501675bcfe0c775459a8140750eb"
       url: "https://pub.dev"
     source: hosted
-    version: "2.12.0"
+    version: "2.13.0"
   boolean_selector:
     dependency: transitive
     description:
@@ -53,10 +53,10 @@ packages:
     dependency: transitive
     description:
       name: fake_async
-      sha256: "6a95e56b2449df2273fd8c45a662d6947ce1ebb7aafe80e550a3f68297f3cacc"
+      sha256: "5368f224a74523e8d2e7399ea1638b37aecfca824a3cc4dfdf77bf1fa905ac44"
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.2"
+    version: "1.3.3"
   file:
     dependency: transitive
     description:
@@ -91,15 +91,15 @@ packages:
       path: "../.."
       relative: true
     source: path
-    version: "0.3.0"
+    version: "0.4.0"
   leak_tracker:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: c35baad643ba394b40aac41080300150a4f08fd0fd6a10378f8f7c6bc161acec
+      sha256: "6bb818ecbdffe216e81182c2f0714a2e62b593f4a4f13098713ff1685dfb6ab0"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.8"
+    version: "10.0.9"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
@@ -261,18 +261,18 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: "0968250880a6c5fe7edc067ed0a13d4bae1577fe2771dcf3010d52c4a9d3ca14"
+      sha256: ddfa8d30d89985b96407efce8acbdd124701f96741f2d981ca860662f1c0dc02
       url: "https://pub.dev"
     source: hosted
-    version: "14.3.1"
+    version: "15.0.0"
   webdriver:
     dependency: transitive
     description:
       name: webdriver
-      sha256: "3d773670966f02a646319410766d3b5e1037efb7f07cc68f844d5e06cd4d61c8"
+      sha256: "2f3a14ca026957870cfd9c635b83507e0e51d8091568e90129fbf805aba7cade"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.4"
+    version: "3.1.0"
 sdks:
   dart: ">=3.7.0-0 <4.0.0"
   flutter: ">=3.27.0"

--- a/lib/navigator_observer.dart
+++ b/lib/navigator_observer.dart
@@ -1,0 +1,78 @@
+import 'package:flutter/widgets.dart';
+import 'package:fullstory_flutter/fs.dart';
+
+/// Function used to generate or update properties for a page
+/// when transitioning from [previous] to [current].
+///
+/// [previous] will be null for the first page in the app.
+typedef PagePropertiesFactory = Map<String, Object?>? Function(
+    Route<dynamic> current, Route<dynamic>? previous);
+
+/// A [NavigatorObserver] that tracks [Navigator] page transitions
+/// and captures them in Fullstory.
+///
+/// Pages are automatically created, started and cached for reuse
+/// as the user navigates through the app.
+class FSNavigatorObserver extends NavigatorObserver {
+  final _namedPages = <String, FSPage>{};
+
+  /// Generates page names to be sent to Fullstory from [Route]s.
+  ///
+  /// The name should be consistent for each logical page or section in your
+  /// app.
+  /// See [FS.page] for more details, and [namePageDefault] for an example
+  /// implementation.
+  final String Function(Route<dynamic>) namePage;
+
+  /// Generates page properties to set when a page is created with [FS.page]
+  ///
+  /// Only called when the page is visited for the first time.
+  final PagePropertiesFactory initialProperties;
+
+  /// Generates page properties to pass to [FSPage.updateProperties] with on a
+  /// subsequent visit.
+  ///
+  /// Returned properties will be merged with the existing properties.
+  final PagePropertiesFactory updateProperties;
+
+  /// Creates a [FSNavigatorObserver].
+  ///
+  /// [namePageDefault] is the default value for [namePage].
+  /// [propertiesDefault] is the default value for [initialProperties] and
+  /// [updateProperties].
+  FSNavigatorObserver({
+    this.namePage = namePageDefault,
+    this.initialProperties = propertiesDefault,
+    this.updateProperties = propertiesDefault,
+  });
+
+  @override
+  void didChangeTop(Route<dynamic> topRoute, Route<dynamic>? previousTopRoute) {
+    final cached = _namedPages[topRoute.settings.name];
+    if (cached != null) {
+      final properties = updateProperties(topRoute, previousTopRoute);
+      cached.start(propertyUpdates: properties);
+      return;
+    }
+
+    final name = namePage(topRoute);
+    final properties = initialProperties(topRoute, previousTopRoute);
+    final page = FS.page(name, properties: properties);
+    _namedPages[name] = page;
+    page.start();
+  }
+}
+
+/// Default page name generator. Uses the name set in [RouteSettings],
+/// such as with [Navigator.pushNamed].
+///
+/// If names are not set (such as using [Navigator.push]),
+/// the page will show as 'unknown' in Fullstory.
+String namePageDefault(Route<dynamic> route) {
+  return route.settings.name ?? 'unknown';
+}
+
+/// Default null [PagePropertiesFactory].
+Map<String, Object?>? propertiesDefault(Route<dynamic> current, Route<dynamic>? previous) {
+  return null;
+}

--- a/lib/navigator_observer.dart
+++ b/lib/navigator_observer.dart
@@ -73,6 +73,7 @@ String namePageDefault(Route<dynamic> route) {
 }
 
 /// Default null [PagePropertiesFactory].
-Map<String, Object?>? propertiesDefault(Route<dynamic> current, Route<dynamic>? previous) {
+Map<String, Object?>? propertiesDefault(
+    Route<dynamic> current, Route<dynamic>? previous) {
   return null;
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,7 +8,7 @@ environment:
   flutter: ">=3.3.0"
 
 dependencies:
-  fake_async: ^1.3.3
+  fake_async: ^1.3.2
   flutter:
     sdk: flutter
   plugin_platform_interface: ^2.0.2

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,6 +8,7 @@ environment:
   flutter: ">=3.3.0"
 
 dependencies:
+  fake_async: ^1.3.3
   flutter:
     sdk: flutter
   plugin_platform_interface: ^2.0.2

--- a/test/navigator_observer_test.dart
+++ b/test/navigator_observer_test.dart
@@ -118,20 +118,11 @@ class FakeFullstoryFlutterPlatform
   Future<void> releasePage(int pageId) async {}
 }
 
-class FakeRoute extends Route<dynamic> {
+class FakeRoute extends Route<dynamic> with Fake {
   final String? name;
 
   FakeRoute({this.name});
 
   @override
   RouteSettings get settings => RouteSettings(name: name);
-
-  @override
-  bool get isCurrent => true;
-
-  @override
-  bool get isFirst => false;
-
-  @override
-  bool get isActive => true;
 }

--- a/test/navigator_observer_test.dart
+++ b/test/navigator_observer_test.dart
@@ -1,0 +1,137 @@
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fullstory_flutter/navigator_observer.dart';
+import 'package:fullstory_flutter/src/fullstory_flutter_platform_interface.dart';
+import 'package:plugin_platform_interface/plugin_platform_interface.dart';
+import 'package:fake_async/fake_async.dart';
+
+void main() {
+  late FakeFullstoryFlutterPlatform fakePlatform;
+
+  setUp(() {
+    fakePlatform = FakeFullstoryFlutterPlatform();
+    FullstoryFlutterPlatform.instance = fakePlatform;
+  });
+
+  group(FSNavigatorObserver, () {
+    test('page created with initial properties', () {
+      fakeAsync((async) {
+        final observer = FSNavigatorObserver(
+          namePage: (route) => 'test_page',
+          initialProperties: (_, __) => {'key': 'value'},
+        );
+
+        observer.didChangeTop(FakeRoute(), null);
+        async.flushMicrotasks();
+
+        expect(fakePlatform.startedPages, ['test_page']);
+        expect(fakePlatform.pageProperties.length, 1);
+        expect(fakePlatform.pageProperties, {
+          'test_page': {'key': 'value'}
+        });
+      });
+    });
+
+    test('page updated with new properties', () {
+      fakeAsync((async) {
+        final observer = FSNavigatorObserver(
+          // Use route.settings.name for pages names since we're using
+          // the default namePage
+          initialProperties: (_, __) => {'key': 'value'},
+          updateProperties: (_, __) => {'new_key': 'new_value'},
+        );
+
+        observer.didChangeTop(FakeRoute(name: 'one'), null);
+        async.flushMicrotasks();
+        observer.didChangeTop(FakeRoute(name: 'one'), FakeRoute(name: 'two'));
+        async.flushMicrotasks();
+
+        expect(fakePlatform.startedPages, ['one', 'one']);
+        expect(fakePlatform.pageProperties['one'], {'new_key': 'new_value'});
+      });
+    });
+  });
+
+  group('namePageDefault', () {
+    test('namePageDefault returns route name', () {
+      final observer = FSNavigatorObserver();
+      final route = FakeRoute(name: 'test_page');
+      final name = observer.namePage(route);
+      expect(name, 'test_page');
+    });
+
+    test('namePageDefault returns unknown if route name is null', () {
+      final observer = FSNavigatorObserver();
+      final route = FakeRoute();
+      final name = observer.namePage(route);
+      expect(name, 'unknown');
+    });
+  });
+}
+
+class FakeFullstoryFlutterPlatform
+    with MockPlatformInterfaceMixin, Fake
+    implements FullstoryFlutterPlatform {
+  final pageProperties = <String, Map<String, Object?>>{};
+  final pageIds = <int, String>{};
+  var _nextPageId = 0;
+  final startedPages = <String>[];
+  final releasedPages = <String>[];
+
+  @override
+  Future<int> page(String pageName, Map<String, Object?> properties) async {
+    final pageId = _nextPageId++;
+    pageProperties[pageName] = properties;
+    pageIds[pageId] = pageName;
+    return pageId;
+  }
+
+  @override
+  Future<void> startPage(
+      int pageId, Map<String, Object?> propertyUpdates) async {
+    final name = _nameFor(pageId);
+    if (propertyUpdates.isNotEmpty) {
+      pageProperties[name] = propertyUpdates;
+    }
+
+    startedPages.add(name);
+  }
+
+  @override
+  Future<void> updatePageProperties(
+      int pageId, Map<String, Object?> properties) async {
+    final name = _nameFor(pageId);
+    pageProperties[name] = properties;
+  }
+
+  String _nameFor(int pageId) {
+    final name = pageIds[pageId];
+    if (name == null) {
+      throw Exception('No page with id $pageId');
+    }
+    return name;
+  }
+
+  // Does nothing, but needs to be here since this will be called by
+  // FSPage.dispose()
+  @override
+  Future<void> releasePage(int pageId) async {}
+}
+
+class FakeRoute extends Route<dynamic> {
+  final String? name;
+
+  FakeRoute({this.name});
+
+  @override
+  RouteSettings get settings => RouteSettings(name: name);
+
+  @override
+  bool get isCurrent => true;
+
+  @override
+  bool get isFirst => false;
+
+  @override
+  bool get isActive => true;
+}


### PR DESCRIPTION
FSNavigatorObserver allows a developer to define arbitrary names and properties for Flutter Routes as they are observed being pushed by the Navigator. 

For an app using [named routes](https://docs.flutter.dev/cookbook/navigation/named-routes), this works really well (since they already have names!) For other apps, we offer a callback to get a name based on a Route. We also offer functions to allow clients to set properties on pages as Routes appear.

This adds a direct dependency on the [fake_async](https://pub.dev/packages/fake_async) package, which is owned by the Google dart team and is a [direct dependency](https://api.flutter.dev/flutter/flutter_test/AutomatedTestWidgetsFlutterBinding/runTest.html) of the flutter_test package (so it's already indirectly part of our binary). 

This *doesn't* work with [go_router](https://pub.dev/packages/go_router), the package Flutter is pushing to replace the named route system. It would be pretty easy to build an equivalent thing, but I don't think we want to pull go_router in as a dependency, so if we ever need to, I think we'd ship that as a separate package.

Example Session: https://app.staging.fullstory.com/ui/KWH/session/3803018792983741558:3923079467763552138