### PR TITLE
Fix proguard rule for plugin class name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.7.1
+
+- Addressed a Proguard bug affecting Android's ability to capture sessions.
+
 ## 0.7.0
 
 - Added session replay capability. To use, replace your existing `runApp()`

--- a/android/proguard-rules.pro
+++ b/android/proguard-rules.pro
@@ -1,4 +1,4 @@
--keep class com.fullstory.FSCaptureViolatorKt {*;}
+-keep class com.fullstory.FSViolatorKt {*;}
 -keep class io.flutter.embedding.android.FlutterView {*;}
 -keep class io.flutter.embedding.android.FlutterSurfaceView {*;}
 -keep class io.flutter.embedding.android.FlutterTextureView {*;}

--- a/android/proguard-rules.pro
+++ b/android/proguard-rules.pro
@@ -2,5 +2,5 @@
 -keep class io.flutter.embedding.android.FlutterView {*;}
 -keep class io.flutter.embedding.android.FlutterSurfaceView {*;}
 -keep class io.flutter.embedding.android.FlutterTextureView {*;}
--keep class com.fullstory.flutter.fullstory_capture.FullstoryCapturePlugin {*;}
+-keep class com.fullstory.flutter.fullstory_capture.FullstoryFlutterPlugin {*;}
 -keep class com.fullstory.FSViolatorKt {*;}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: fullstory_flutter
 description: 'Visual capture support for Fullstory session replay'
-version: 0.7.0
+version: 0.7.1
 homepage: 'https://www.fullstory.com/platform/mobile-apps/'
 
 environment:


### PR DESCRIPTION
The class name changed but the proguard rule did not, so we could not find the class and the SDK thought the plugin wasn't present, breaking capture.